### PR TITLE
Fix indentation for markdown links in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -65,5 +65,5 @@ body:
   - type: markdown
     attributes:
       value: |
-      [COLLAB]: https://github.com/c-h-david/rapid2/blob/main/CODE_OF_COLLAB.md
-      [CONTRI]: https://github.com/c-h-david/rapid2/blob/main/CONTRIBUTING.md
+        [COLLAB]: https://github.com/c-h-david/rapid2/blob/main/CODE_OF_COLLAB.md
+        [CONTRI]: https://github.com/c-h-david/rapid2/blob/main/CONTRIBUTING.md

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -37,5 +37,5 @@ body:
   - type: markdown
     attributes:
       value: |
-      [COLLAB]: https://github.com/c-h-david/rapid2/blob/main/CODE_OF_COLLAB.md
-      [CONTRI]: https://github.com/c-h-david/rapid2/blob/main/CONTRIBUTING.md
+        [COLLAB]: https://github.com/c-h-david/rapid2/blob/main/CODE_OF_COLLAB.md
+        [CONTRI]: https://github.com/c-h-david/rapid2/blob/main/CONTRIBUTING.md


### PR DESCRIPTION
# Purpose
- Fix YAML formatting errors in GitHub issue templates that were causing HTTP 500 errors when accessing the templates page

## Proposed Changes
- [FIX] Corrected indentation in markdown link references in bug_report.yml
- [FIX] Corrected indentation in markdown link references in enhancement.yml

## Issues
- Fixes HTTP 500 error when accessing https://github.com/c-h-david/rapid2/tree/main/.github/ISSUE_TEMPLATE (try this)

## Testing
- Verified proper YAML syntax in both template files after changes
- Confirmed correct indentation of markdown link references within the value blocks
- Changes have been committed and should resolve the template rendering issues when pushed to GitHub