### PR TITLE
Fix hadolint-bin version to 2.14.0

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -30,7 +30,7 @@ wheel==0.44.0
 # Packages for code checking
 # -----------------------------------------------------------------------------
 flake8==7.1.1
-hadolint-bin==2.12.0
+hadolint-bin==2.14.0
 mypy==1.11.2
 pymarkdownlnt==0.9.24
 yamllint==1.35.1


### PR DESCRIPTION
## Purpose

This PR fixes the `pipx install` failure caused by an unavailable dependency version. The package hadolint-bin version 2.12.0 does not exist on PyPI, preventing successful installation of the rapid2 package.

## Proposed Changes

- [FIX] Updated hadolint-bin dependency from version 2.12.0 to 2.14.0 in requirements.pip

## Issues

- Resolves #17

## Testing

- Verified `pipx install .` completes successfully and hadolint 2.14.0 functions correctly on macOS (Darwin 24.6.0)