### PR TITLE
CLI flag consistency: add short and long flag names

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,6 @@ pip3 install .
 ### Run Instructions
 
 ```bash
-rapid2 -nl namelist_Sandbox.yml
-```
-
-OR
-
-```bash
 rapid2 --namelist namelist_Sandbox.yml
 ```
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -116,7 +116,7 @@ rapid2 --namelist input/Tutorial/namelist_Tutorial.yml
 cmpncf \
     --previous \
     input/Tutorial/Qinit_pfaf_74_GLDAS_2.1_VIC_2010-01_GOLD.nc4 \
-    --current \
+    --now \
     input/Tutorial/Qinit_pfaf_74_GLDAS_2.1_VIC_2010-01.nc4 \
     --relative_tolerance 1e-6 \
     --absolute_tolerance 1e-3
@@ -126,7 +126,7 @@ cmpncf \
 cmpncf \
     --previous \
     input/Tutorial/Qext_pfaf_74_GLDAS_2.1_VIC_2010-01_GOLD.nc4 \
-    --current \
+    --now \
     input/Tutorial/Qext_pfaf_74_GLDAS_2.1_VIC_2010-01.nc4 \
     --relative_tolerance 1e-6 \
     --absolute_tolerance 1e-3
@@ -136,7 +136,7 @@ cmpncf \
 cmpncf \
     --previous \
     output/Tutorial/Qout_pfaf_74_GLDAS_2.1_VIC_2010-01_GOLD.nc4 \
-    --current \
+    --now \
     output/Tutorial/Qout_pfaf_74_GLDAS_2.1_VIC_2010-01.nc4 \
     --relative_tolerance 1e-6 \
     --absolute_tolerance 1e-3
@@ -146,7 +146,7 @@ cmpncf \
 cmpncf \
     --previous \
     output/Tutorial/Qfinal_pfaf_74_GLDAS_2.1_VIC_2010-01_GOLD.nc4 \
-    --current \
+    --now \
     output/Tutorial/Qfinal_pfaf_74_GLDAS_2.1_VIC_2010-01.nc4 \
     --relative_tolerance 1e-6 \
     --absolute_tolerance 1e-3

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -37,10 +37,11 @@ Download GLDAS phase `2.1`, model `VIC`, for `2010-01`:
 
 ``` bash
 dgldas2 \
-    --phs 2.1 \
-    --mod VIC \
-    --tim 2010-01 \
-    --lsm input/Tutorial/GLDAS_2.1_VIC_2010-01.nc4
+    --phase 2.1 \
+    --model VIC \
+    --time 2010-01 \
+    --land_surface_model \
+    input/Tutorial/GLDAS_2.1_VIC_2010-01.nc4
 ```
 
 The new file is placed in `input/Tutorial`. Other files are also automatically
@@ -54,19 +55,26 @@ Convert the GLDAS runoff file into RAPID external inflow format:
 
 ``` bash
 cpllsm \
-    --lsm input/Tutorial/GLDAS_2.1_VIC_2010-01.nc4 \
-    --con input/Tutorial/rapid_connect_pfaf_74.csv \
-    --crd input/Tutorial/coords_pfaf_74.csv \
-    --cpl input/Tutorial/rapid_coupling_pfaf_74_GLDAS.csv \
-    --Qex input/Tutorial/Qext_pfaf_74_GLDAS_2.1_VIC_2010-01.nc4
+    --land_surface_model \
+    input/Tutorial/GLDAS_2.1_VIC_2010-01.nc4 \
+    --connectivity \
+    input/Tutorial/rapid_connect_pfaf_74.csv \
+    --coordinates \
+    input/Tutorial/coords_pfaf_74.csv \
+    --coupling \
+    input/Tutorial/rapid_coupling_pfaf_74_GLDAS.csv \
+    --external_inflow \
+    input/Tutorial/Qext_pfaf_74_GLDAS_2.1_VIC_2010-01.nc4
 ```
 
 ## 4. Create Cold Start File with `zeroqinit`
 
 ``` bash
 zeroqinit \
-    --Qex input/Tutorial/Qext_pfaf_74_GLDAS_2.1_VIC_2010-01.nc4 \
-    --Q00 input/Tutorial/Qinit_pfaf_74_GLDAS_2.1_VIC_2010-01.nc4
+    --external_inflow \
+    input/Tutorial/Qext_pfaf_74_GLDAS_2.1_VIC_2010-01.nc4 \
+    --initial_outflow \
+    input/Tutorial/Qinit_pfaf_74_GLDAS_2.1_VIC_2010-01.nc4
 ```
 
 ## 5. Run the Routing Model with `rapid2`
@@ -99,41 +107,49 @@ Qfi_ncf: './output/Tutorial/Qfinal_pfaf_74_GLDAS_2.1_VIC_2010-01_tst.nc4'
 ```
 
 ``` bash
-rapid2 --nml input/Tutorial/namelist_Tutorial.yml
+rapid2 --namelist input/Tutorial/namelist_Tutorial.yml
 ```
 
 ## 6. Compare Files to Baseline with `cmpncf`
 
 ``` bash
 cmpncf \
-    --prv input/Tutorial/Qinit_pfaf_74_GLDAS_2.1_VIC_2010-01_GOLD.nc4 \
-    --now input/Tutorial/Qinit_pfaf_74_GLDAS_2.1_VIC_2010-01.nc4 \
-    --rtl 1e-6 \
-    --atl 1e-3
+    --previous \
+    input/Tutorial/Qinit_pfaf_74_GLDAS_2.1_VIC_2010-01_GOLD.nc4 \
+    --current \
+    input/Tutorial/Qinit_pfaf_74_GLDAS_2.1_VIC_2010-01.nc4 \
+    --relative_tolerance 1e-6 \
+    --absolute_tolerance 1e-3
 ```
 
 ```bash
 cmpncf \
-    --prv input/Tutorial/Qext_pfaf_74_GLDAS_2.1_VIC_2010-01_GOLD.nc4 \
-    --now input/Tutorial/Qext_pfaf_74_GLDAS_2.1_VIC_2010-01.nc4 \
-    --rtl 1e-6 \
-    --atl 1e-3
+    --previous \
+    input/Tutorial/Qext_pfaf_74_GLDAS_2.1_VIC_2010-01_GOLD.nc4 \
+    --current \
+    input/Tutorial/Qext_pfaf_74_GLDAS_2.1_VIC_2010-01.nc4 \
+    --relative_tolerance 1e-6 \
+    --absolute_tolerance 1e-3
 ```
 
 ``` bash
 cmpncf \
-    --prv output/Tutorial/Qout_pfaf_74_GLDAS_2.1_VIC_2010-01_GOLD.nc4 \
-    --now output/Tutorial/Qout_pfaf_74_GLDAS_2.1_VIC_2010-01.nc4 \
-    --rtl 1e-6 \
-    --atl 1e-3
+    --previous \
+    output/Tutorial/Qout_pfaf_74_GLDAS_2.1_VIC_2010-01_GOLD.nc4 \
+    --current \
+    output/Tutorial/Qout_pfaf_74_GLDAS_2.1_VIC_2010-01.nc4 \
+    --relative_tolerance 1e-6 \
+    --absolute_tolerance 1e-3
 ```
 
 ```bash
 cmpncf \
-    --prv output/Tutorial/Qfinal_pfaf_74_GLDAS_2.1_VIC_2010-01_GOLD.nc4 \
-    --now output/Tutorial/Qfinal_pfaf_74_GLDAS_2.1_VIC_2010-01.nc4 \
-    --rtl 1e-6 \
-    --atl 1e-3
+    --previous \
+    output/Tutorial/Qfinal_pfaf_74_GLDAS_2.1_VIC_2010-01_GOLD.nc4 \
+    --current \
+    output/Tutorial/Qfinal_pfaf_74_GLDAS_2.1_VIC_2010-01.nc4 \
+    --relative_tolerance 1e-6 \
+    --absolute_tolerance 1e-3
 ```
 
 ## Current Known Challenges to Command Line Interface

--- a/src/_cmpncf.py
+++ b/src/_cmpncf.py
@@ -40,14 +40,14 @@ def main() -> None:
             "  cmpncf "
             "--previous "
             "input/Tutorial/Qinit_GLDAS_2.1_VIC_2010-01_GOLD.nc4 "
-            "--current "
+            "--now "
             "input/Tutorial/Qinit_GLDAS_2.1_VIC_2010-01.nc4 "
             "--relative_tolerance 1e-6 "
             "--absolute_tolerance 1e-3\n"
             "  cmpncf "
             "--previous "
             "input/Tutorial/Qext_GLDAS_2.1_VIC_2010-01_GOLD.nc4 "
-            "--current "
+            "--now "
             "input/Tutorial/Qext_GLDAS_2.1_VIC_2010-01.nc4 "
             "--relative_tolerance 1e-6 "
             "--absolute_tolerance 1e-3"
@@ -71,9 +71,9 @@ def main() -> None:
 
     parser.add_argument(
         "-now",
-        "--current",
+        "--now",
         dest="now",
-        metavar="CURRENT",
+        metavar="NOW",
         type=str,
         required=True,
         help="specify the new netCDF file",

--- a/src/_cmpncf.py
+++ b/src/_cmpncf.py
@@ -38,13 +38,19 @@ def main() -> None:
         epilog=(
             "examples:\n"
             "  cmpncf "
-            "--prv input/Tutorial/Qinit_GLDAS_2.1_VIC_2010-01_GOLD.nc4 "
-            "--now input/Tutorial/Qinit_GLDAS_2.1_VIC_2010-01.nc4 "
-            "--rtl 1e-6 --atl 1e-3\n"
+            "--previous "
+            "input/Tutorial/Qinit_GLDAS_2.1_VIC_2010-01_GOLD.nc4 "
+            "--current "
+            "input/Tutorial/Qinit_GLDAS_2.1_VIC_2010-01.nc4 "
+            "--relative_tolerance 1e-6 "
+            "--absolute_tolerance 1e-3\n"
             "  cmpncf "
-            "--prv input/Tutorial/Qext_GLDAS_2.1_VIC_2010-01_GOLD.nc4 "
-            "--now input/Tutorial/Qext_GLDAS_2.1_VIC_2010-01.nc4 "
-            "--rtl 1e-6 --atl 1e-3"
+            "--previous "
+            "input/Tutorial/Qext_GLDAS_2.1_VIC_2010-01_GOLD.nc4 "
+            "--current "
+            "input/Tutorial/Qext_GLDAS_2.1_VIC_2010-01.nc4 "
+            "--relative_tolerance 1e-6 "
+            "--absolute_tolerance 1e-3"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -54,21 +60,30 @@ def main() -> None:
     )
 
     parser.add_argument(
-        "--prv",
+        "-prv",
+        "--previous",
+        dest="prv",
+        metavar="PREVIOUS",
         type=str,
         required=True,
         help="specify the old netCDF file",
     )
 
     parser.add_argument(
-        "--now",
+        "-now",
+        "--current",
+        dest="now",
+        metavar="CURRENT",
         type=str,
         required=True,
         help="specify the new netCDF file",
     )
 
     parser.add_argument(
-        "--rtl",
+        "-rtl",
+        "--relative_tolerance",
+        dest="rtl",
+        metavar="RELATIVE_TOLERANCE",
         type=str,
         required=False,
         default="0",
@@ -76,7 +91,10 @@ def main() -> None:
     )
 
     parser.add_argument(
-        "--atl",
+        "-atl",
+        "--absolute_tolerance",
+        dest="atl",
+        metavar="ABSOLUTE_TOLERANCE",
         type=str,
         required=False,
         default="0",

--- a/src/_cpllsm.py
+++ b/src/_cpllsm.py
@@ -41,11 +41,17 @@ def main() -> None:
         ),
         epilog=(
             "examples:\n"
-            "  cpllsm --lsm input/Tutorial/GLDAS_2.1_VIC_2010-01.nc4 "
-            "--con input/Tutorial/rapid_connect_pfaf_74.csv "
-            "--crd input/Tutorial/coords_pfaf_74.csv "
-            "--cpl input/Tutorial/rapid_coupling_pfaf_74_GLDAS.csv "
-            "--Qex input/Tutorial/Qext_GLDAS_2.1_VIC_2010-01.nc4"
+            "  cpllsm "
+            "--land_surface_model "
+            "input/Tutorial/GLDAS_2.1_VIC_2010-01.nc4 "
+            "--connectivity "
+            "input/Tutorial/rapid_connect_pfaf_74.csv "
+            "--coordinates "
+            "input/Tutorial/coords_pfaf_74.csv "
+            "--coupling "
+            "input/Tutorial/rapid_coupling_pfaf_74_GLDAS.csv "
+            "--external_inflow "
+            "input/Tutorial/Qext_GLDAS_2.1_VIC_2010-01.nc4"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -55,32 +61,53 @@ def main() -> None:
     )
 
     parser.add_argument(
-        "--lsm", type=str, required=True, help="specify the LSM file"
+        "-lsm",
+        "--land_surface_model",
+        dest="lsm",
+        metavar="LAND_SURFACE_MODEL",
+        type=str,
+        required=True,
+        help="specify the LSM file",
     )
 
     parser.add_argument(
-        "--con",
+        "-con",
+        "--connectivity",
+        dest="con",
+        metavar="CONNECTIVITY",
         type=str,
         required=True,
         help="specify the connectivity file",
     )
 
     parser.add_argument(
-        "--crd",
+        "-crd",
+        "--coordinates",
+        dest="crd",
+        metavar="COORDINATES",
         type=str,
         required=True,
         help="specify the coordinates",
     )
 
     parser.add_argument(
-        "--cpl",
+        "-cpl",
+        "--coupling",
+        dest="cpl",
+        metavar="COUPLING",
         type=str,
         required=True,
         help="specify the coupling file",
     )
 
     parser.add_argument(
-        "--Qex", type=str, required=True, help="specify the file name"
+        "-Qex",
+        "--external_inflow",
+        dest="Qex",
+        metavar="EXTERNAL_INFLOW",
+        type=str,
+        required=True,
+        help="specify the file name",
     )
 
     # -------------------------------------------------------------------------

--- a/src/_dgldas2.py
+++ b/src/_dgldas2.py
@@ -35,8 +35,9 @@ def main() -> None:
         ),
         epilog=(
             "examples:\n"
-            "  dgldas2 --phs 2.1 --mod VIC --tim 2010-01 "
-            "--lsm input/Tutorial/GLDAS_2.1_VIC_2010-01.nc4"
+            "  dgldas2 --phase 2.1 --model VIC --time 2010-01 "
+            "--land_surface_model "
+            "input/Tutorial/GLDAS_2.1_VIC_2010-01.nc4"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -46,28 +47,43 @@ def main() -> None:
     )
 
     parser.add_argument(
-        "--phs",
+        "-phs",
+        "--phase",
+        dest="phs",
+        metavar="PHASE",
         type=str,
         required=True,
         help="specify the phase number",
     )
 
     parser.add_argument(
-        "--mod",
+        "-mod",
+        "--model",
+        dest="mod",
+        metavar="MODEL",
         type=str,
         required=True,
         help="specify the land surface model",
     )
 
     parser.add_argument(
-        "--tim",
+        "-tim",
+        "--time",
+        dest="tim",
+        metavar="TIME",
         type=str,
         required=True,
         help="specify the month in yyyy-mm",
     )
 
     parser.add_argument(
-        "--lsm", type=str, required=True, help="specify the LSM file name"
+        "-lsm",
+        "--land_surface_model",
+        dest="lsm",
+        metavar="LAND_SURFACE_MODEL",
+        type=str,
+        required=True,
+        help="specify the LSM file name",
     )
 
     # -------------------------------------------------------------------------

--- a/src/_m3rivtoqext.py
+++ b/src/_m3rivtoqext.py
@@ -35,7 +35,8 @@ def main() -> None:
         ),
         epilog=(
             "examples:\n"
-            "  m3rivtoqext --m3r m3_riv_San_Guad.nc4 --Qex Qext_San_Guad.nc4"
+            "  m3rivtoqext --inflow_volume m3_riv_San_Guad.nc4 "
+            "--external_inflow Qext_San_Guad.nc4"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -45,14 +46,20 @@ def main() -> None:
     )
 
     parser.add_argument(
-        "--m3r",
+        "-m3r",
+        "--inflow_volume",
+        dest="m3r",
+        metavar="INFLOW_VOLUME",
         type=str,
         required=True,
         help="specify the input m3_riv file",
     )
 
     parser.add_argument(
-        "--Qex",
+        "-Qex",
+        "--external_inflow",
+        dest="Qex",
+        metavar="EXTERNAL_INFLOW",
         type=str,
         required=True,
         help="specify the output Qext file",

--- a/src/_m3rivtoqext.py
+++ b/src/_m3rivtoqext.py
@@ -47,7 +47,7 @@ def main() -> None:
 
     parser.add_argument(
         "-m3r",
-        "--inflow_volume",
+        "--external_volume",
         dest="m3r",
         metavar="INFLOW_VOLUME",
         type=str,

--- a/src/_m3rivtoqext.py
+++ b/src/_m3rivtoqext.py
@@ -49,7 +49,7 @@ def main() -> None:
         "-m3r",
         "--external_volume",
         dest="m3r",
-        metavar="INFLOW_VOLUME",
+        metavar="EXTERNAL_VOLUME",
         type=str,
         required=True,
         help="specify the input m3_riv file",

--- a/src/_rapid2.py
+++ b/src/_rapid2.py
@@ -47,8 +47,8 @@ def main() -> None:
         ),
         epilog=(
             "examples:\n"
-            "  rapid2 --nml input/Sandbox/namelist_Sandbox.yml\n"
-            "  rapid2 --nml input/Tutorial/namelist_Tutorial.yml"
+            "  rapid2 --namelist input/Sandbox/namelist_Sandbox.yml\n"
+            "  rapid2 --namelist input/Tutorial/namelist_Tutorial.yml"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -58,7 +58,10 @@ def main() -> None:
     )
 
     parser.add_argument(
-        "--nml",
+        "-nml",
+        "--namelist",
+        dest="nml",
+        metavar="NAMELIST",
         type=str,
         required=True,
         help="specify the namelist file",

--- a/src/_sandboxqext.py
+++ b/src/_sandboxqext.py
@@ -35,8 +35,8 @@ def main() -> None:
         ),
         epilog=(
             "examples:\n"
-            "  sandboxqext --scl 1 1 1 2 2 --avg 10 10 10 20 20 "
-            "--Qex Qext_Sandbox.nc"
+            "  sandboxqext --scale 1 1 1 2 2 --average 10 10 10 "
+            "20 20 --external_inflow Qext_Sandbox.nc"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -46,7 +46,10 @@ def main() -> None:
     )
 
     parser.add_argument(
-        "--scl",
+        "-scl",
+        "--scale",
+        dest="scl",
+        metavar="SCALE",
         type=float,
         required=True,
         nargs=5,
@@ -54,7 +57,10 @@ def main() -> None:
     )
 
     parser.add_argument(
-        "--avg",
+        "-avg",
+        "--average",
+        dest="avg",
+        metavar="AVERAGE",
         type=float,
         required=True,
         nargs=5,
@@ -62,7 +68,10 @@ def main() -> None:
     )
 
     parser.add_argument(
-        "--Qex",
+        "-Qex",
+        "--external_inflow",
+        dest="Qex",
+        metavar="EXTERNAL_INFLOW",
         type=str,
         required=True,
         help="specify the output Qext file",

--- a/src/_zeroqinit.py
+++ b/src/_zeroqinit.py
@@ -35,8 +35,11 @@ def main() -> None:
         ),
         epilog=(
             "examples:\n"
-            "  zeroqinit --Qex input/Tutorial/Qext_GLDAS_2.1_VIC_2010-01.nc4 "
-            "--Q00 input/Tutorial/Qinit_GLDAS_2.1_VIC_2010-01.nc4"
+            "  zeroqinit "
+            "--external_inflow "
+            "input/Tutorial/Qext_GLDAS_2.1_VIC_2010-01.nc4 "
+            "--initial_outflow "
+            "input/Tutorial/Qinit_GLDAS_2.1_VIC_2010-01.nc4"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -46,14 +49,20 @@ def main() -> None:
     )
 
     parser.add_argument(
-        "--Qex",
+        "-Qex",
+        "--external_inflow",
+        dest="Qex",
+        metavar="EXTERNAL_INFLOW",
         type=str,
         required=True,
         help="specify the input Qext file",
     )
 
     parser.add_argument(
-        "--Q00",
+        "-Q00",
+        "--initial_outflow",
+        dest="Q00",
+        metavar="INITIAL_OUTFLOW",
         type=str,
         required=True,
         help="specify the output Qinit file",


### PR DESCRIPTION
Converts all CLI flags from double-dash shorthand (e.g. `--nml`) to single-dash short flags with descriptive long names (e.g. `-nml` / `--namelist`), adds `dest` and `metavar` for clean help output, and updates all documentation (README, TUTORIAL) to use the long name form. Resolves #35.